### PR TITLE
Improve secure context check

### DIFF
--- a/packages/component/src/ReactDocumentPictureInPicture.tsx
+++ b/packages/component/src/ReactDocumentPictureInPicture.tsx
@@ -131,8 +131,8 @@ const ReactDocumentPictureInPicture = forwardRef<
 
 
     let featureUnavailableReason: FeatureUnavailableReasonEnum | null = (() => {
-        const isUsingSecureProtocol = window.isSecureContext;
-        if (isUsingSecureProtocol === false) return FeatureUnavailableReasonEnum.USING_UNSECURE_PROTOCOL;
+        const isSecureContext = window.isSecureContext;
+        if (isSecureContext === false) return FeatureUnavailableReasonEnum.USING_UNSECURE_PROTOCOL;
 
         const featureIsAvailable = 'documentPictureInPicture' in window;
         if (featureIsAvailable === false) return FeatureUnavailableReasonEnum.API_NOT_SUPPORTED;

--- a/packages/component/src/ReactDocumentPictureInPicture.tsx
+++ b/packages/component/src/ReactDocumentPictureInPicture.tsx
@@ -131,7 +131,7 @@ const ReactDocumentPictureInPicture = forwardRef<
 
 
     let featureUnavailableReason: FeatureUnavailableReasonEnum | null = (() => {
-        const isUsingSecureProtocol = window.location.protocol === 'https:';
+        const isUsingSecureProtocol = window.isSecureContext;
         if (isUsingSecureProtocol === false) return FeatureUnavailableReasonEnum.USING_UNSECURE_PROTOCOL;
 
         const featureIsAvailable = 'documentPictureInPicture' in window;


### PR DESCRIPTION
There are various flavours of `localhost` which are considered secure, but the current guard prevents testing on `http://localhost`